### PR TITLE
Add example of rendering toggles in script embedded on page

### DIFF
--- a/backend/FeatureToggles.WebApi/Config/FeatureToggleOptions.cs
+++ b/backend/FeatureToggles.WebApi/Config/FeatureToggleOptions.cs
@@ -1,10 +1,21 @@
 using FeatureToggles.Domain;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace FeatureToggles.WebApi.Config
 {
     public class FeatureToggleOptions
     {
+        private static JsonSerializerSettings _serializerSettings = new JsonSerializerSettings
+        {
+            Converters = new[] { new StringEnumConverter() },
+            Formatting = Formatting.None
+        };
+
         public bool IsFirstFeatureEnabled { get; set; }
         public SecondFeatureVariant SecondFeatureVariant { get; set; }
+
+        public string ToJson()
+            => JsonConvert.SerializeObject(this, _serializerSettings);
     }
 }

--- a/backend/FeatureToggles.WebApi/Controllers/EmbeddedClientController.cs
+++ b/backend/FeatureToggles.WebApi/Controllers/EmbeddedClientController.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+
+namespace FeatureToggles.WebApi.Controllers
+{
+    [Route("EmbeddedClient")]
+    public class EmbeddedClientController : Controller
+    {
+        public IActionResult Index()
+        {
+            return View();
+        }
+    }
+}

--- a/backend/FeatureToggles.WebApi/Controllers/FeatureToggleController.cs
+++ b/backend/FeatureToggles.WebApi/Controllers/FeatureToggleController.cs
@@ -1,4 +1,5 @@
-﻿using FeatureToggles.WebApi.Config;
+﻿using System.Net;
+using FeatureToggles.WebApi.Config;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 
@@ -16,7 +17,7 @@ namespace FeatureToggles.WebApi.Controllers
         }
 
         [HttpGet]
-        public FeatureToggleOptions Get()
+        public ActionResult<FeatureToggleOptions> Get()
             => _featureToggles;
     }
 }

--- a/backend/FeatureToggles.WebApi/Controllers/FeatureToggleController.cs
+++ b/backend/FeatureToggles.WebApi/Controllers/FeatureToggleController.cs
@@ -1,0 +1,22 @@
+﻿using FeatureToggles.WebApi.Config;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+
+namespace FeatureToggles.WebApi.Controllers
+{
+    [Route("api/FeatureToggles")]
+    public class FeatureToggleController : Controller
+    {
+        private readonly FeatureToggleOptions _featureToggles;
+
+        public FeatureToggleController(
+            IOptionsSnapshot<FeatureToggleOptions> featureToggles)
+        {
+            this._featureToggles = featureToggles.Value;
+        }
+
+        [HttpGet]
+        public FeatureToggleOptions Get()
+            => _featureToggles;
+    }
+}

--- a/backend/FeatureToggles.WebApi/Startup.cs
+++ b/backend/FeatureToggles.WebApi/Startup.cs
@@ -38,6 +38,7 @@ namespace FeatureToggles.WebApi
                 app.UseHsts();
             }
 
+            app.UseCors(c => c.AllowAnyOrigin().AllowAnyMethod().AllowAnyHeader());
             app.UseHttpsRedirection();
             app.UseStaticFiles();
             app.UseMvc();

--- a/backend/FeatureToggles.WebApi/Startup.cs
+++ b/backend/FeatureToggles.WebApi/Startup.cs
@@ -39,6 +39,7 @@ namespace FeatureToggles.WebApi
             }
 
             app.UseHttpsRedirection();
+            app.UseStaticFiles();
             app.UseMvc();
         }
     }

--- a/backend/FeatureToggles.WebApi/Views/EmbeddedClient/Index.cshtml
+++ b/backend/FeatureToggles.WebApi/Views/EmbeddedClient/Index.cshtml
@@ -1,0 +1,19 @@
+﻿@using FeatureToggles.WebApi.Config
+@using Microsoft.Extensions.Options
+
+@inject IOptionsSnapshot<FeatureToggleOptions> _featureToggles
+
+<html>
+<head>
+    <title>Embedded client</title>
+    <script type="text/javascript">
+        window.FeatureToggles = @Html.Raw(_featureToggles.Value.ToJson());
+    </script>
+</head>
+<body>
+    First feature is @(_featureToggles.Value.IsFirstFeatureEnabled ? "enabled" : "disabled")
+    <button onclick="toggleMessage()">Toggle message</button>
+    <h1 id="message"></h1>
+    <script type="text/javascript" src="~/ClientScript.js"></script>
+</body>
+</html>

--- a/backend/FeatureToggles.WebApi/appsettings.json
+++ b/backend/FeatureToggles.WebApi/appsettings.json
@@ -6,7 +6,7 @@
     },
     "AllowedHosts": "*",
     "FeatureToggles": {
-        "IsFirstFeatureEnabled": false,
+        "IsFirstFeatureEnabled": true,
         "SecondFeatureVariant": "Second"
     }
 }

--- a/backend/FeatureToggles.WebApi/wwwroot/ClientScript.js
+++ b/backend/FeatureToggles.WebApi/wwwroot/ClientScript.js
@@ -1,0 +1,9 @@
+﻿function toggleMessage() {
+    var messageElem = document.getElementById('message');
+    if (messageElem.innerText) {
+        messageElem.innerText = '';
+    }
+    else {
+        messageElem.innerText = FeatureToggles.SecondFeatureVariant;
+    }
+}

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -4,7 +4,7 @@ import Button from "@material-ui/core/Button";
 import Snackbar from "@material-ui/core/Snackbar";
 import SnackbarContentWrapper from "./SnackbarContentWrapper";
 
-function App() {
+function App({ featureToggles }) {
   const [openFeature1, setOpenFeature1] = React.useState(false);
   const [openFeature2, setOpenFeature2] = React.useState(false);
   const [openFeature3, setOpenFeature3] = React.useState(false);
@@ -35,26 +35,30 @@ function App() {
 
   return (
     <div className="App">
-      <div className="button-container">
-        <Button onClick={handleClick1} variant="contained" color="default">
-          Feature 1
-        </Button>
-        <Snackbar
-          anchorOrigin={{
-            vertical: "top",
-            horizontal: "center"
-          }}
-          open={openFeature1}
-          autoHideDuration={4000}
-          onClose={handleClose1}
-        >
-          <SnackbarContentWrapper
-            onClose={handleClose1}
-            variant="success"
-            message="Feature 1 is enabled"
-          />
-        </Snackbar>
-      </div>
+      {
+        featureToggles.isFirstFeatureEnabled && (
+          <div className="button-container">
+            <Button onClick={handleClick1} variant="contained" color="default">
+              Feature 1
+            </Button>
+            <Snackbar
+              anchorOrigin={{
+                vertical: "top",
+                horizontal: "center"
+              }}
+              open={openFeature1}
+              autoHideDuration={4000}
+              onClose={handleClose1}
+            >
+              <SnackbarContentWrapper
+                onClose={handleClose1}
+                variant="success"
+                message="Feature 1 is enabled"
+              />
+            </Snackbar>
+          </div>
+        )
+      }
 
       <div className="button-container">
         <Button onClick={handleClick2} variant="contained" color="primary">
@@ -72,7 +76,7 @@ function App() {
           <SnackbarContentWrapper
             onClose={handleClose2}
             variant="info"
-            message="Feature 2 in variant 1"
+            message={`Feature 2 in variant ${featureToggles.secondFeatureVariant}`}
           />
         </Snackbar>
       </div>

--- a/frontend/src/featureToggles.js
+++ b/frontend/src/featureToggles.js
@@ -1,0 +1,4 @@
+export default {
+    isFirstFeatureEnabled: false,
+    secondFeatureVariant: 0
+};

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -4,7 +4,13 @@ import './index.css';
 import App from './App';
 import * as serviceWorker from './serviceWorker';
 
-ReactDOM.render(<App />, document.getElementById('root'));
+var apiUrl = 'http://localhost:52401'
+
+fetch(`${apiUrl}/api/FeatureToggles`)
+    .then(response => response.json())
+    .then(featureToggles => {
+        ReactDOM.render(<App featureToggles={featureToggles} />, document.getElementById('root'));
+    });
 
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -3,14 +3,18 @@ import ReactDOM from 'react-dom';
 import './index.css';
 import App from './App';
 import * as serviceWorker from './serviceWorker';
+import defaultFeatureToggles from './featureToggles';
 
-var apiUrl = 'http://localhost:52401'
+const apiUrl = 'http://localhost:52401'
 
 fetch(`${apiUrl}/api/FeatureToggles`)
     .then(response => response.json())
     .then(featureToggles => {
         ReactDOM.render(<App featureToggles={featureToggles} />, document.getElementById('root'));
-    });
+    })
+    .catch(() => {
+        ReactDOM.render(<App featureToggles={defaultFeatureToggles} />, document.getElementById('root'));
+    })
 
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.


### PR DESCRIPTION
This shows example of how feature toggle values can be used in JavaScript
without the need for providing any backend endpoint. They are rendered as
JSON inside <script> block and assigned to global variable `FeatureToggles`.
This way they are accessible from anywhere inside JavaScript.